### PR TITLE
Fix typo in fr-FR locale Step6

### DIFF
--- a/src/lib/locales/fr-FR.json
+++ b/src/lib/locales/fr-FR.json
@@ -122,7 +122,7 @@
   "Step2": "Voici un onglet, Pour le modifier ou le supprimer, Tu peux faire Clique Droit dessus",
   "Step3": "En cliquant sur le +, tu peux ajouter un nouvelle onglet",
   "Step4": "En cliquant sur ce bouton, tu peux ajouter une nouvelle liste",
-  "Step6": "Ceci est une liste, pour la modiifer et la supprimer tu peux faire un clic droit sur le nom de la liste",
+  "Step6": "Ceci est une liste, pour la modifier et la supprimer tu peux faire un clic droit sur le nom de la liste",
   "Step8": "Ceci est une tâche, pour la modifier et la supprimer tu peux faire un clic droit sur le nom de la tâche",
   "Step9": "C’est bon, tu es prêt ! Tu connais maintenant les bases de Yfokon. Il ne reste plus qu’à te lancer et faire avancer tes projets.",
   "EraseOrUseTitle": "Ecrasez ou Utiliser ?",


### PR DESCRIPTION
Corrects a spelling mistake in src/lib/locales/fr-FR.json (Step6): changes 'modiifer' to 'modifier' to fix the French text.